### PR TITLE
Sets up the basics for hot reloading config.cson.

### DIFF
--- a/src/nvim/config.coffee
+++ b/src/nvim/config.coffee
@@ -7,6 +7,8 @@ path = require 'path'
 cson = require 'cson'
 app = remote.require 'app'
 
+user_config_file_name = path.join app.getPath('userData'), 'config.cson'
+
 # default
 config =
   fg_color: '#000'
@@ -15,13 +17,19 @@ config =
   col: 40
   font: '13px Inconsolata, Monaco, Consolas, \'Source Code Pro\', \'Ubuntu Mono\', \'DejaVu Sans Mono\', \'Courier New\', Courier, monospace'
   blink_cursor: true
+  # user_path: user_config_file_name
+  user_path: app.getPath("userData")
+  reload: ->
+    changed = false
+    try
+      user_config = cson.load user_config_file_name
+      if user_config not instanceof Error
+        for k of config
+          if user_config[k]?
+            changed = true if @[k] != user_config[k]
+            @[k] = user_config[k]
+    return changed
 
-user_config_file_name = path.join app.getPath('userData'), 'config.cson'
-try
-  user_config = cson.load user_config_file_name
-  if user_config not instanceof Error
-    for k of config
-      if user_config[k]?
-        config[k] = user_config[k]
+config.reload()
 
 module.exports = config

--- a/src/nvim/key_handler.coffee
+++ b/src/nvim/key_handler.coffee
@@ -138,6 +138,7 @@ exports.keystrokeForKeyboardEvent = (event) ->
     else
       key = key.toLowerCase() if /^[A-Z]$/.test(key)
     keystroke += 'D-' if event.metaKey
+    key = "lt" if key == "<" and not keystroke.length
     keystroke += key
     if keystroke.length == 1 then keystroke else '<' + keystroke + '>'
 
@@ -169,7 +170,7 @@ keyFromCharCode = (charCode) ->
     when 13 then 'Enter'
     when 27 then 'Esc'
     when 32 then 'Space'
-    when 60 then 'lt'
+    when 60 then '<'
     when 92 then 'Bslash'
     when 124 then 'Bar'
     when 127 then 'Del'

--- a/src/nvim/nvim.coffee
+++ b/src/nvim/nvim.coffee
@@ -68,7 +68,8 @@ config_handler = (ui) ->
       console.log JSON.stringify(config)
       ui.init_font()
       ui.init_cursor()
-      ui.nv_resize config.col, config.row
+      ui.emit "resize", config.col, config.row
+      ui.emit "input", "<C-l>"
     else
       console.log "samesies"
   , 250

--- a/src/nvim/nvim.coffee
+++ b/src/nvim/nvim.coffee
@@ -7,6 +7,27 @@ Session = require 'msgpack5rpc'
 remote = require 'remote'
 UI = require './ui'
 config = require './config'
+fs = require 'fs'
+
+
+# Returns a function, that, as long as it continues to be invoked, will not
+# be triggered. The function will be called after it stops being called for
+# N milliseconds. If `immediate` is passed, trigger the function on the
+# leading edge, instead of the trailing.
+debounce = (func, wait, immediate) ->
+  timeout = undefined
+  ->
+    context = this
+    args = arguments
+    later = ->
+      timeout = null
+      func.apply context, args  unless immediate
+      return
+    callNow = immediate and not timeout
+    clearTimeout timeout
+    timeout = setTimeout(later, wait)
+    func.apply context, args  if callNow
+    return
 
 class NVim
   constructor: ->
@@ -34,6 +55,24 @@ class NVim
         @session.request 'vim_input', [e], ->
       @ui.on 'resize', (col, row) =>
         @session.request 'ui_try_resize', [col, row], ->
+
+    ui = @ui
+    # Watch the directory because vim replaces a file.
+    # We could also watch both the file and the directory and
+    # rely on the debounce to handle it.
+    fs.watch config.user_path, persistent: true, config_handler(ui)
+
+config_handler = (ui) ->
+  debounce (event) ->
+    if config.reload()
+      console.log JSON.stringify(config)
+      ui.init_font()
+      ui.init_cursor()
+      ui.nv_resize config.col, config.row
+    else
+      console.log "samesies"
+  , 250
+
 
 
 module.exports = NVim

--- a/src/nvim/ui.coffee
+++ b/src/nvim/ui.coffee
@@ -32,7 +32,7 @@ class UI extends EventEmitter
     @init_font()
     @init_cursor()
     @init_event_handlers()
-    @nv_resize row, col
+    @nv_resize col, row
 
   init_DOM: ->
     @canvas = document.getElementById 'nvas-canvas'


### PR DESCRIPTION
Watches the userData directory for changes and then reloads the appropriate settings. It currently watches the directory because text editors replace the file written with a temporary copy, which breaks `fs.watch` in many cases. Perhaps using a third party watcher would be better, but also another dependency. `fs.watch` also triggered multiple times for a text editor write, so I added a 250ms debounce.

It works as far as I can tell, I wasn't 100% sure which calls were neccessary to reset the config
or which function would be best to call to redraw the whole editor. I used nv_resize in the end.

Note: Oh dear god, I used `hub pull-request` and it set the title incorrectly.
