### PR TITLE
Fix scrolling coordinates

### DIFF
--- a/src/nvim/ui.coffee
+++ b/src/nvim/ui.coffee
@@ -194,7 +194,9 @@ class UI extends EventEmitter
         direction = if rows > 0 then 'Up' else 'Down'
 
       @emit 'input', get_vim_button_name('ScrollWheel' + direction, e) \
-        + '<' + cols + ',' + rows + '>'
+        + '<' + Math.floor(e.clientX / @char_width) \
+        + ',' + Math.floor(e.clientY / @char_height) \
+        + '>'
 
       if config.blink_cursor
         pause_blink()


### PR DESCRIPTION
These coordinates represent the scroll event location.
Before this fix if you had `NERDTree` open (on the left) and was trying to scroll the document, only the `NERDTree` split scrolled.
After the fix the split you have your mouse over is scrolled.
